### PR TITLE
removed deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,11 +36,11 @@
 
 - name: Initialize swap file
   command: mkswap {{ swapfile_path }}
-  when: (swapfile_register_create | changed and not swapfile_delete)
+  when: (swapfile_register_create is changed and not swapfile_delete)
 
 - name: Enable swap file
   command: swapon {{ swapfile_path }}
-  when: (swapfile_register_create | changed and not swapfile_delete)
+  when: (swapfile_register_create is changed and not swapfile_delete)
 
 - name: Manage swap file in /etc/fstab
   mount:


### PR DESCRIPTION
just removed warming

```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|changed` use `result is changed`. This feature will be removed in version 2.9. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```